### PR TITLE
Add support for authenticating using workload-identity towards Google

### DIFF
--- a/.github/actions/docker-build-gcp/action.yml
+++ b/.github/actions/docker-build-gcp/action.yml
@@ -10,8 +10,14 @@ inputs:
     required: true
     description: The docker file to use when building the image
   service_account_key:
-    required: true
-    description: The GCP service account to use to push the docker image
+    required: false
+    description: The GCP service account JSON key used to authenticate towards Google
+  service_account:
+    required: false
+    description: The GCP service account used to authenticate towards Google
+  workload_identity_provider:
+    required: false
+    description: The GCP workload identity provider used to authenticate towards Google
   token:
     required: false
     description: A token used by the Dockerfile
@@ -19,10 +25,18 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Authenticate towards google
+    - name: Authenticate towards Google
+      if: ${{ inputs.service_account_key != '' }}
       uses: google-github-actions/auth@v1
       with:
         credentials_json: ${{ inputs.service_account_key }}
+
+    - name: Authenticate towards Google
+      if: ${{ inputs.workload_identity_provider != '' }}
+      uses: google-github-actions/auth@v1
+      with:
+        workload_identity_provider: ${{ inputs.workload_identity_provider }}
+        service_account: ${{ inputs.service_account }}
 
     - name: Setup gcloud SDK
       uses: google-github-actions/setup-gcloud@v1

--- a/.github/actions/terraform-deploy-gcp/action.yml
+++ b/.github/actions/terraform-deploy-gcp/action.yml
@@ -12,8 +12,14 @@ inputs:
     default: ./deploy
     description: The directory within the repo containing the terraform code
   service_account_key:
-    required: true
+    required: false
     description: The GCP service account to used to create resources in GCP
+  service_account:
+    required: false
+    description: The GCP service account used to authenticate towards Google
+  workload_identity_provider:
+    required: false
+    description: The GCP workload identity provider used to authenticate towards Google
   token:
     required: false
     description: The secrets.GITHUB_TOKEN
@@ -21,10 +27,18 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Authenticate towards google
+    - name: Authenticate towards Google
+      if: ${{ inputs.service_account_key != '' }}
       uses: google-github-actions/auth@v1
       with:
         credentials_json: ${{ inputs.service_account_key }}
+
+    - name: Authenticate towards Google
+      if: ${{ inputs.workload_identity_provider != '' }}
+      uses: google-github-actions/auth@v1
+      with:
+        workload_identity_provider: ${{ inputs.workload_identity_provider }}
+        service_account: ${{ inputs.service_account }}
 
     - name: Setup gcloud SDK
       uses: google-github-actions/setup-gcloud@v1


### PR DESCRIPTION
Using workload identities is the preferred way to authenticate towards Google rather than using a JSON blob. This is controlled through the two new parameters:

* service_account:
* workload_identity_provider:
