### PR TITLE
Added missing arg to trivy scanner

### DIFF
--- a/.github/actions/terraform-deploy-gcp/action.yml
+++ b/.github/actions/terraform-deploy-gcp/action.yml
@@ -79,6 +79,8 @@ runs:
       id: trivy
       uses: aquasecurity/trivy-action@master
       with:
+        scan-type: 'config'
+        hide-progress: false
         format: 'table'
         exit-code: '1'
         ignore-unfixed: true


### PR DESCRIPTION
Added missing "scan-type: config"

# Description

Fixed bug where security scanner was missing parameter

## Change management

Change classification?
- [ ] Emergency/Critical
- [ ] Significant
- [ ] Minor
- [x] Standard (standard changes are documented by the team with standard rollback plan)

Change risk
- [ ] Critical
- [ ] High 
- [ ] Medium
- [x] Low

Change reason?

Fix bug

Change rollback plan?

Please describe the rollback plan here (if applicable) .

Standard rollback plan applies

