### PR TITLE
Continue on Trivy security errors

### DIFF
--- a/.github/actions/terraform-deploy-gcp/action.yml
+++ b/.github/actions/terraform-deploy-gcp/action.yml
@@ -7,6 +7,10 @@ inputs:
     required: false
     description: Should pull requests be deployed
     default: false
+  continue_on_security_warnings:
+    required: false
+    description: Should the pipeline block on security warnings
+    default: true
   directory:
     required: true
     default: ./deploy
@@ -80,11 +84,12 @@ runs:
       uses: aquasecurity/trivy-action@master
       with:
         scan-type: 'config'
-        hide-progress: false
+        hide-progress: true
         format: 'table'
         exit-code: '1'
         ignore-unfixed: true
         severity: 'CRITICAL,HIGH'
+      continue-on-error: ${{ inputs.continue_on_security_warnings }}
 
     - name: Terraform Plan
       id: plan


### PR DESCRIPTION
Add configuration to config var on Trivy errors

# Description

Added config param to allow workflow to continue if Trivy sec scan fails

Fixes # (issue)

## Change management

Change classification?
- [ ] Emergency/Critical
- [ ] Significant
- [ ] Minor
- [x] Standard (standard changes are documented by the team with standard rollback plan)

Change risk
- [ ] Critical
- [ ] High 
- [ ] Medium
- [x] Low

Change reason?

Some times you want to continue even though there are errors.

Change rollback plan?

Standard change applies

