### PR TITLE
Fix error when checking continue_on_security_warnings input

### DIFF
--- a/.github/actions/terraform-deploy-gcp/action.yml
+++ b/.github/actions/terraform-deploy-gcp/action.yml
@@ -84,12 +84,11 @@ runs:
       uses: aquasecurity/trivy-action@master
       with:
         scan-type: 'config'
-        hide-progress: true
         format: 'table'
         exit-code: '1'
         ignore-unfixed: true
         severity: 'CRITICAL,HIGH'
-      continue-on-error: ${{ inputs.continue_on_security_warnings }}
+      continue-on-error: ${{ inputs.continue_on_security_warnings == 'true' }}
 
     - name: Terraform Plan
       id: plan


### PR DESCRIPTION
# Description

Fix bug where continue_on_security_warnings was incorrectly validated

## Change management

Change classification?
- [ ] Emergency/Critical
- [ ] Significant
- [ ] Minor
- [x] Standard (standard changes are documented by the team with standard rollback plan)

Change risk
- [ ] Critical
- [ ] High 
- [ ] Medium
- [x] Low

Change reason?

Fix bug

Change rollback plan?

Standard rollback plan applies
