### PR TITLE
Add image_push parameter to docker-build-gcp

### DIFF
--- a/.github/actions/docker-build-gcp/action.yml
+++ b/.github/actions/docker-build-gcp/action.yml
@@ -9,6 +9,10 @@ inputs:
   image_name:
     required: true
     description: Name of docker image to build and publish
+  push_image:
+    required: false
+    description: Should the image be pushed to the repository
+    default: true
   tag:
     required: false
     description: Optional tag to apply to the docker image
@@ -83,7 +87,7 @@ runs:
         build-args: |
           TOKEN=${{ inputs.token }}
         file: ${{ inputs.dockerfile }}
-        push: true
+        push: ${{ inputs.push_image }}
         tags: ${{ steps.metadata.outputs.tags }}
         labels: ${{ steps.metadata.outputs.labels }}
 

--- a/examples/release.yml
+++ b/examples/release.yml
@@ -6,6 +6,8 @@ on:
         description: Release version (v0.0.0)
         required: true
 
+run-name: Release ${{ inputs.version }}
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Added image_push parameter to docker-build-gcp action to allow workflow to control if image should be pushed or just built as a dry run

## Change management

Change classification?
- [ ] Emergency/Critical
- [ ] Significant
- [ ] Minor
- [x] Standard (standard changes are documented by the team with standard rollback plan)

Change risk
- [ ] Critical
- [ ] High 
- [ ] Medium
- [x] Low

Change reason?

Give the workflow the option too choose to push the docker image being built

Change rollback plan?

Standard rollback plan applies

# How Has This Been Tested?

N/A

# Checklist (definition of done):

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

