### PR TITLE
Change Trivy scanner from config to misconfig

### DIFF
--- a/.github/actions/terraform-deploy-gcp/action.yml
+++ b/.github/actions/terraform-deploy-gcp/action.yml
@@ -86,7 +86,7 @@ runs:
         scan-ref: ${{ inputs.directory }}
         scan-type: 'fs'
         hide-progress: true
-        scanners: 'secret,config'
+        scanners: 'secret,misconfig'
         format: 'table'
         exit-code: '1'
         ignore-unfixed: true


### PR DESCRIPTION
The Trivy security scanner now require the scanner misconfig instead of the old config.

## Change management

Change classification?
- [ ] Emergency/Critical
- [ ] Significant
- [ ] Minor
- [x] Standard (standard changes are documented by the team with standard rollback plan)

Change risk
- [ ] Critical
- [ ] High 
- [ ] Medium
- [x] Low

Change reason?

Fix bug

Change rollback plan?

Standard rollback plan applies

# How Has This Been Tested?

N/A

# Checklist (definition of done):

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

