### PR TITLE
Remove required input parameter repository

### DIFF
--- a/.github/actions/terraform-deploy-gcp/action.yml
+++ b/.github/actions/terraform-deploy-gcp/action.yml
@@ -15,9 +15,6 @@ inputs:
     required: true
     default: ./deploy
     description: The directory within the repo containing the terraform code
-  repository:
-    required: true
-    description: The repository to deploy to
   token:
     required: false
     description: The secrets.GITHUB_TOKEN


### PR DESCRIPTION
The input parameter repository is no longer required and used.

## Change management

See project labels for change classification and risk.

Change reason?

Code maintenance

Change rollback plan?

If nothing else is specified, the change will be rolled back by reverting the commit.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration
