### PR TITLE
Set version for Trivy and update version for actions/checkout

### DIFF
--- a/.github/actions/terraform-deploy-gcp/action.yml
+++ b/.github/actions/terraform-deploy-gcp/action.yml
@@ -50,7 +50,7 @@ runs:
 
     - name: Run Trivy vulnerability scanner
       id: trivy
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@0.29.0
       with:
         scan-ref: ${{ inputs.directory }}
         scan-type: 'fs'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     environment: production
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - uses: ./.github/actions/release
         with:
           version: ${{ inputs.VERSION }}

--- a/examples/development.yml
+++ b/examples/development.yml
@@ -20,7 +20,7 @@ jobs:
       dockerfile: ${{ steps.build.outputs.dockerfile }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - uses: pexip/shared-github-actions/.github/actions/auth-gcp@master
         id: auth-gcp
         with:
@@ -40,7 +40,7 @@ jobs:
     environment: development
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - uses: pexip/shared-github-actions/.github/actions/auth-gcp@master
         id: auth-gcp
         with:
@@ -59,7 +59,7 @@ jobs:
     environment: development
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set Terraform variables
         shell: bash
         run: |

--- a/examples/production.yml
+++ b/examples/production.yml
@@ -19,7 +19,7 @@ jobs:
     environment: production
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set Terraform variables
         shell: bash
         run: |

--- a/examples/release.yml
+++ b/examples/release.yml
@@ -14,7 +14,7 @@ jobs:
     environment: production
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - uses: pexip/shared-github-actions/.github/actions/release@master
         with:
           version: ${{ inputs.VERSION }}


### PR DESCRIPTION
# Description

* Update the Trivy check to use a specific version instead of master.
* Also update actions/checkout to use v4 instead of v3 (ref VJ-752)

## Change management

See project labels for change classification and risk.

# How Has This Been Tested?

Not yet tested
