### PR TITLE
Let the docker build context parameter through.

### DIFF
--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -9,6 +9,10 @@ inputs:
   image_name:
     required: true
     description: Name of docker image to build and publish
+  context:
+    required: false
+    description: The context to use when building the image
+    default: .
   push_image:
     required: false
     description: Should the image be pushed to the repository
@@ -67,7 +71,7 @@ runs:
         TOKEN:  ${{ inputs.TOKEN }}
       uses: docker/build-push-action@v5
       with:
-        context: .
+        context: ${{ inputs.context }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
         build-args: |


### PR DESCRIPTION
# Description

This PR adds a context parameter and passes it on to docker/build-push-action@v5.

Fixes # (issue)

## Change management

See project labels for change classification and risk.

Change reason?

When the Docker file is not at the root of the repo it is possible to specify where the docker file is, but the build context is still the top level of the repo.  By allowing context to be passed through we avoid the need to rewrite the Docker file to make CI work.

Change rollback plan?

If nothing else is specified, the change will be rolled back by reverting the commit.

# How Has This Been Tested?

This is just a suggestion, and it has not been tested.
