### PR TITLE
Fix secret syntax in action.yml for gh_token input

### DIFF
--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -73,7 +73,7 @@ runs:
         cache-from: type=gha
         cache-to: type=gha,mode=max
         secrets: |
-          "gh_token=${{ inputs.gh_token }}"
+          gh_token=${{ inputs.gh_token }}
         file: ${{ inputs.dockerfile }}
         push: ${{ inputs.push_image }}
         tags: ${{ steps.metadata.outputs.tags }}


### PR DESCRIPTION
# Description

Fixes the syntax for passing the GitHub token as a secret in the Docker build action by removing unnecessary quotes around the secret assignment.

- Corrected the `gh_token` secret syntax from quoted string format to proper key-value format
