### PR TITLE
Fix path resolution for PR comment script in action.yml

### DIFF
--- a/terraform-deploy-gcp-action/action.yml
+++ b/terraform-deploy-gcp-action/action.yml
@@ -89,7 +89,8 @@ runs:
       with:
         github-token: ${{ inputs.token }}
         script: |
-          const prComment = require('${{ github.workspace }}/_shared/terraform-pr-comment.js');
+          const path = require('path');
+          const prComment = require(path.join('${{ github.action_path }}', '..', '_shared', 'terraform-pr-comment.js'));
 
           await prComment.createOrUpdatePRComment({
             github,

--- a/terraform-deploy-openstack-action/action.yml
+++ b/terraform-deploy-openstack-action/action.yml
@@ -86,7 +86,8 @@ runs:
       with:
         github-token: ${{ inputs.token }}
         script: |
-          const prComment = require('${{ github.workspace }}/_shared/terraform-pr-comment.js');
+          const path = require('path');
+          const prComment = require(path.join('${{ github.action_path }}', '..', '_shared', 'terraform-pr-comment.js'));
 
           await prComment.createOrUpdatePRComment({
             github,


### PR DESCRIPTION
# Description

This pull request updates how the shared `terraform-pr-comment.js` module is imported in both the GCP and OpenStack Terraform deploy GitHub Actions. The change ensures that the module is required using a path relative to the action's directory, which improves compatibility and reliability in different execution environments.

**Improvements to module import paths:**

* Updated the import of `terraform-pr-comment.js` in `terraform-deploy-gcp-action/action.yml` to use `path.join` with `github.action_path`, making the require statement more robust and less dependent on the workspace structure.
* Made the same update in `terraform-deploy-openstack-action/action.yml` for consistency and reliability across actions.

## Change management

See project labels for change classification and risk.

Change reason?

Please describe the reason for the change here.

Change rollback plan?

If nothing else is specified, the change will be rolled back by reverting the commit.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration
