### PR TITLE
Add Azure authentication action

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ GitHub Actions workflows and actions accessible to all Pexip workflows. This rep
 
 ### Authentication
 
+- **[auth-azure-action](auth-azure-action)** - Authenticate with Microsoft Azure using service principal credentials or workload identity (OIDC)
 - **[auth-gcp-action](auth-gcp-action)** - Authenticate with Google Cloud Platform using service account key or workload identity federation
 - **[auth-github-action](auth-github-action)** - Authenticate with GitHub Container Registry
 
@@ -160,6 +161,54 @@ steps:
       dockerfile: Dockerfile
 ```
 
+### Example: Authenticate with Azure
+
+Azure authentication supports two methods:
+
+#### Service Principal (credentials JSON)
+
+```yaml
+steps:
+  - name: Checkout
+    uses: actions/checkout@v4
+
+  - uses: pexip/shared-github-actions/auth-azure-action@master
+    with:
+      credentials: ${{ secrets.AZURE_CREDENTIALS }}
+      registry: myregistry.azurecr.io
+```
+
+The `AZURE_CREDENTIALS` secret should contain JSON in this format:
+```json
+{
+  "clientId": "<client-id>",
+  "clientSecret": "<client-secret>",
+  "subscriptionId": "<subscription-id>",
+  "tenantId": "<tenant-id>"
+}
+```
+
+#### Workload Identity (OIDC)
+
+For enhanced security without storing secrets, use OIDC/Workload Identity:
+
+```yaml
+permissions:
+  id-token: write
+  contents: read
+
+steps:
+  - name: Checkout
+    uses: actions/checkout@v4
+
+  - uses: pexip/shared-github-actions/auth-azure-action@master
+    with:
+      client_id: ${{ secrets.AZURE_CLIENT_ID }}
+      tenant_id: ${{ secrets.AZURE_TENANT_ID }}
+      subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      registry: myregistry.azurecr.io
+```
+
 ### Example: Create a Release
 
 ```yaml
@@ -185,6 +234,10 @@ Configure these secrets in your repository settings:
 
 ### Optional Secrets
 
+- **`AZURE_CREDENTIALS`** - Azure service principal credentials JSON (if using auth-azure-action with service principal)
+- **`AZURE_CLIENT_ID`** - Azure application client ID (if using auth-azure-action with workload identity)
+- **`AZURE_TENANT_ID`** - Azure AD tenant ID (if using auth-azure-action with workload identity)
+- **`AZURE_SUBSCRIPTION_ID`** - Azure subscription ID (if using auth-azure-action with workload identity)
 - **`jira_webhook`** - Jira automation webhook URL for release integration
 
 ### Required Variables

--- a/auth-azure-action/action.yml
+++ b/auth-azure-action/action.yml
@@ -1,0 +1,54 @@
+name: Authenticate towards Azure
+description: Authenticate towards Microsoft Azure
+author: "havard.bakke@pexip.com"
+
+inputs:
+  registry:
+    required: false
+    description: The Azure Container Registry to authenticate against (e.g., myregistry.azurecr.io)
+  credentials:
+    required: false
+    description: Azure service principal credentials JSON (for service principal auth)
+  client_id:
+    required: false
+    description: The Azure application (service principal) client ID (for OIDC/workload identity)
+  tenant_id:
+    required: false
+    description: The Azure AD tenant ID (for OIDC/workload identity)
+  subscription_id:
+    required: false
+    description: The Azure subscription ID (for OIDC/workload identity)
+
+runs:
+  using: "composite"
+  steps:
+    - name: Validate authentication inputs
+      shell: bash
+      run: |
+        if [ -z "${{ inputs.credentials }}" ] && [ -z "${{ inputs.client_id }}" ]; then
+          echo "Error: Either credentials (service principal) or client_id (workload identity) must be provided"
+          exit 1
+        fi
+        if [ -n "${{ inputs.client_id }}" ] && ([ -z "${{ inputs.tenant_id }}" ] || [ -z "${{ inputs.subscription_id }}" ]); then
+          echo "Error: tenant_id and subscription_id are required when using workload identity (client_id)"
+          exit 1
+        fi
+
+    - name: Authenticate towards Azure (service principal)
+      if: ${{ inputs.credentials != '' }}
+      uses: azure/login@v2
+      with:
+        creds: ${{ inputs.credentials }}
+
+    - name: Authenticate towards Azure (workload identity/OIDC)
+      if: ${{ inputs.credentials == '' }}
+      uses: azure/login@v2
+      with:
+        client-id: ${{ inputs.client_id }}
+        tenant-id: ${{ inputs.tenant_id }}
+        subscription-id: ${{ inputs.subscription_id }}
+
+    - name: Login to Azure Container Registry
+      if: ${{ inputs.registry != '' }}
+      shell: bash
+      run: az acr login --name $(echo ${{ inputs.registry }} | cut -d'.' -f1)


### PR DESCRIPTION
# Description

This pull request introduces a new GitHub Action for authenticating with Microsoft Azure and updates the documentation to support its usage. The main focus is to enable workflows to authenticate with Azure either via service principal credentials or workload identity (OIDC), enhancing flexibility and security for Azure-related CI/CD tasks.

### Azure Authentication Action Addition

* Added a new composite GitHub Action, `auth-azure-action`, which supports authentication to Azure using either service principal credentials or workload identity (OIDC). The action validates input parameters and uses the appropriate authentication method based on provided inputs, then optionally logs in to Azure Container Registry. (`auth-azure-action/action.yml`)

### Documentation Updates

* Updated the `README.md` to document the new `auth-azure-action`, including usage instructions for both authentication methods and an example workflow for each. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R16) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R164-R211)
* Added details about required secrets for Azure authentication (`AZURE_CREDENTIALS`, `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`) to the documentation to help users configure their repositories correctly.

## Change management

See project labels for change classification and risk.

Change reason?

Please describe the reason for the change here.

Change rollback plan?

If nothing else is specified, the change will be rolled back by reverting the commit.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration
