### PR TITLE
Add Terraform destroy action for GCP resource management

### DIFF
--- a/terraform-destroy-gcp-action/action.yml
+++ b/terraform-destroy-gcp-action/action.yml
@@ -1,0 +1,45 @@
+name: Terraform destroy
+description: Destroys resources to GCP using Terraform
+author: "havard.bakke@pexip.com"
+
+inputs:
+  directory:
+    required: false
+    default: ./deploy
+    description: The directory within the repo containing the Terraform code
+
+runs:
+  using: "composite"
+  steps:
+    - name: Validate inputs
+      shell: bash
+      run: |
+        if [ ! -d "${{ inputs.directory }}" ]; then
+          echo "Error: Terraform directory not found at ${{ inputs.directory }}"
+          exit 1
+        fi
+
+    - name: Setup gcloud SDK
+      uses: google-github-actions/setup-gcloud@v3
+
+    - name: Setup Terraform
+      uses: hashicorp/setup-terraform@v3
+
+    - name: Terraform Init
+      id: init
+      working-directory: ${{ inputs.directory }}
+      shell: bash
+      run: terraform init
+
+    - name: Terraform Validate
+      id: validate
+      working-directory: ${{ inputs.directory }}
+      shell: bash
+      run: terraform validate -no-color
+      continue-on-error: true
+
+    - name: Terraform Destroy
+      id: destroy
+      working-directory: ${{ inputs.directory }}
+      shell: bash
+      run: terraform destroy -auto-approve


### PR DESCRIPTION
# Description

This pull request introduces a new GitHub Action for destroying resources in Google Cloud Platform (GCP) using Terraform. The action is defined in the new `terraform-destroy-gcp-action/action.yml` file and automates the process of validating the Terraform directory, setting up required tools, and running the destroy command.

Key additions in this pull request:

**New GitHub Action for Terraform Destroy:**

* Adds `terraform-destroy-gcp-action/action.yml`, defining a composite action to automate destroying GCP resources with Terraform.
* Includes input validation to ensure the specified Terraform directory exists before proceeding.
* Sets up the required `gcloud` SDK and Terraform CLI using official setup actions.
* Runs `terraform init`, validates the configuration, and executes `terraform destroy -auto-approve` in the specified directory.

## Change management

See project labels for change classification and risk.

Change reason?

Please describe the reason for the change here.

Change rollback plan?

If nothing else is specified, the change will be rolled back by reverting the commit.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration
