### PR TITLE
Add action to create and push release branches

### DIFF
--- a/release-action/action.yml
+++ b/release-action/action.yml
@@ -45,6 +45,20 @@ runs:
           fi
         fi
 
+    - name: Create release branch
+      shell: bash
+      run: |
+        VERSION="${{ inputs.version }}"
+        BRANCH_NAME="releases/${VERSION}"
+
+        git config user.name "GitHub Actions"
+        git config user.email noreply@github.com
+
+        git checkout -b "${BRANCH_NAME}"
+        git push origin "${BRANCH_NAME}"
+
+        echo "Created and pushed branch: ${BRANCH_NAME}"
+
     - name: Create release
       uses: actions/github-script@v7
       with:


### PR DESCRIPTION
# Description

This pull request adds a new step to the release workflow to automatically create and push a release branch before the release is created.

**Release workflow improvements:**

* Added a step to create and push a new release branch named `releases/<version>` using the provided version input, ensuring that releases are made from a dedicated branch.

## Change management

See project labels for change classification and risk.

Change reason?

Please describe the reason for the change here.

Change rollback plan?

If nothing else is specified, the change will be rolled back by reverting the commit.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration
