### PR TITLE
Upgrade Trivy action and version in GitHub Actions workflow

### DIFF
--- a/terraform-deploy-gcp-action/action.yml
+++ b/terraform-deploy-gcp-action/action.yml
@@ -73,7 +73,6 @@ runs:
         severity: 'MEDIUM,HIGH,CRITICAL'
         skip-dirs: '**/.terraform'
         github-pat: ${{ inputs.token }}
-        version: v0.69.3
       continue-on-error: ${{ inputs.continue_on_security_warnings == 'true' }}
 
     - name: Terraform Plan

--- a/terraform-deploy-gcp-action/action.yml
+++ b/terraform-deploy-gcp-action/action.yml
@@ -11,6 +11,10 @@ inputs:
     required: false
     description: Should the pipeline block on security warnings
     default: "false"
+  skip_trivy_scan:
+    required: false
+    description: Should the Trivy vulnerability scan be skipped
+    default: "false"
   directory:
     required: false
     default: ./deploy
@@ -60,6 +64,7 @@ runs:
       continue-on-error: true
 
     - name: Run Trivy vulnerability scanner
+      if: inputs.skip_trivy_scan != 'true'
       id: trivy
       uses: aquasecurity/trivy-action@97e0b3872f55f89b95b2f65b3dbab56962816478 #0.34.2
       with:

--- a/terraform-deploy-gcp-action/action.yml
+++ b/terraform-deploy-gcp-action/action.yml
@@ -61,7 +61,7 @@ runs:
 
     - name: Run Trivy vulnerability scanner
       id: trivy
-      uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 #0.33.1
+      uses: aquasecurity/trivy-action@97e0b3872f55f89b95b2f65b3dbab56962816478 #0.34.2
       with:
         scan-ref: ${{ inputs.directory }}
         scan-type: 'fs'
@@ -73,7 +73,7 @@ runs:
         severity: 'MEDIUM,HIGH,CRITICAL'
         skip-dirs: '**/.terraform'
         github-pat: ${{ inputs.token }}
-        version: v0.67.0
+        version: v0.69.3
       continue-on-error: ${{ inputs.continue_on_security_warnings == 'true' }}
 
     - name: Terraform Plan


### PR DESCRIPTION
# Description

This pull request updates the vulnerability scanning step in the `terraform-deploy-gcp-action/action.yml` workflow to use newer versions of both the Trivy GitHub Action and the Trivy scanner itself. These updates ensure improved security scanning and compatibility.

Security tool version updates:

* Updated the Trivy GitHub Action from version `0.33.1` to `0.34.2` to incorporate the latest features and fixes.
* Updated the Trivy scanner version from `v0.67.0` to the version used by the github actions module.

## Change management

See project labels for change classification and risk.

Change reason?

Please describe the reason for the change here.

Change rollback plan?

If nothing else is specified, the change will be rolled back by reverting the commit.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration
