### PR TITLE
Enhance PR comment generation by including directory in identifiers to support multiple deployments in a PR

### DIFF
--- a/_shared/terraform-pr-comment.js
+++ b/_shared/terraform-pr-comment.js
@@ -55,6 +55,7 @@ module.exports = {
       // Generate comment content
       const output = this.generateComment({
         platform,
+        directory,
         planOutput,
         planSummary,
         truncated,
@@ -65,7 +66,7 @@ module.exports = {
       });
 
       // Update or create comment
-      await this.updateOrCreateComment({ github, context, output, platform });
+      await this.updateOrCreateComment({ github, context, output, platform, directory });
 
     } catch (error) {
       // Don't fail the workflow if comment fails
@@ -87,9 +88,12 @@ module.exports = {
     outcomes,
     validationOutput,
     commitSha,
-    timestamp
+    timestamp,
+    directory
   }) {
-    const identifier = `<!-- terraform-deploy-${platform}-comment -->`;
+    // Create unique identifier based on platform and directory to support multiple deployments
+    const dirHash = crypto.createHash('md5').update(directory).digest('hex').substring(0, 8);
+    const identifier = `<!-- terraform-deploy-${platform}-${dirHash}-comment -->`;
 
     // Platform-specific emoji/branding
     const platformInfo = {
@@ -163,8 +167,10 @@ ${truncated ? '\n⚠️ **Plan truncated due to size limits. View full plan in w
    * Update existing comment or create new one
    * @param {Object} params - Parameters object
    */
-  async updateOrCreateComment({ github, context, output, platform }) {
-    const identifier = `<!-- terraform-deploy-${platform}-comment -->`;
+  async updateOrCreateComment({ github, context, output, platform, directory }) {
+    // Create unique identifier based on platform and directory to support multiple comments for different deployments in the same PR
+    const dirHash = crypto.createHash('md5').update(directory).digest('hex').substring(0, 8);
+    const identifier = `<!-- terraform-deploy-${platform}-${dirHash}-comment -->`;
 
     // Find existing comment by unique identifier
     const { data: comments } = await github.rest.issues.listComments({

--- a/_shared/terraform-pr-comment.js
+++ b/_shared/terraform-pr-comment.js
@@ -122,7 +122,7 @@ module.exports = {
     return `${identifier}
 ## ${emoji} Terraform Plan Results - ${name}
 
-**Commit:** \`${commitSha}\` | **Triggered:** ${timestamp}
+**Directory:** \`${directory}\` | **Commit:** \`${commitSha}\` | **Triggered:** ${timestamp}
 
 ### Step Results
 


### PR DESCRIPTION
This pull request updates the logic for generating and managing Terraform PR comments to support multiple deployments within the same pull request. The main improvement is the introduction of a unique identifier for each deployment comment, based on both the platform and the deployment directory, ensuring that comments for different directories don't overwrite each other.

**Support for multiple deployment comments:**

* Updated the comment generation and update logic in `_shared/terraform-pr-comment.js` to include the deployment `directory` when generating the comment identifier, using an MD5 hash of the directory to create a unique suffix. This allows multiple deployment comments (e.g., for different directories) to coexist in the same PR. [[1]](diffhunk://#diff-76d8176f19830822e53c072e3aa26cfe5a2a96f2fdafafce985797f3ef468853L90-R96) [[2]](diffhunk://#diff-76d8176f19830822e53c072e3aa26cfe5a2a96f2fdafafce985797f3ef468853L166-R173)

* Modified the parameters passed to `generateComment` and `updateOrCreateComment` to include the `directory`, ensuring that all relevant functions have access to the new identifier logic. [[1]](diffhunk://#diff-76d8176f19830822e53c072e3aa26cfe5a2a96f2fdafafce985797f3ef468853R58) [[2]](diffhunk://#diff-76d8176f19830822e53c072e3aa26cfe5a2a96f2fdafafce985797f3ef468853L68-R69)